### PR TITLE
Implement category creation and selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Open `frontend/index.html` in your browser. The frontend expects the backend to 
 - Summary of expenses by category
 - Add new financial entries when expanding categories
 - On-demand reports filtered by category and period
+- Create custom expense categories and assign them when recording expenses
 
 This is a basic starting point and does not include full authentication or a production-ready setup.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -25,6 +25,20 @@ def read_summary(db: Session = Depends(get_db)):
         summaries[cat_name] += transaction
     return [schemas.CategorySummary(category=k, total=v) for k, v in summaries.items()]
 
+
+@app.get("/categories", response_model=list[schemas.Category])
+def read_categories(db: Session = Depends(get_db)):
+    return db.query(models.Category).all()
+
+
+@app.post("/categories", response_model=schemas.Category)
+def create_category(category: schemas.CategoryCreate, db: Session = Depends(get_db)):
+    db_cat = models.Category(name=category.name)
+    db.add(db_cat)
+    db.commit()
+    db.refresh(db_cat)
+    return db_cat
+
 @app.post("/transactions", response_model=schemas.Transaction)
 def create_transaction(transaction: schemas.TransactionCreate, db: Session = Depends(get_db)):
     db_trans = models.Transaction(**transaction.dict())

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -27,3 +27,6 @@ class CategorySummary(BaseModel):
     category: str
     total: float
 
+class CategoryCreate(BaseModel):
+    name: str
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,17 @@
 </head>
 <body>
   <h1>Financial Controller</h1>
+  <div id="addExpense">
+    <h2>Add Expense</h2>
+    <label>Category:
+      <select id="expenseCategory"></select>
+      <button onclick="addCategory()">Add Category</button>
+    </label>
+    <label>Description: <input type="text" id="expenseDescription"></label>
+    <label>Amount: <input type="number" id="expenseAmount"></label>
+    <label>Date: <input type="date" id="expenseDate"></label>
+    <button onclick="submitExpense()">Add Expense</button>
+  </div>
   <div id="summary"></div>
   <div id="report">
     <h2>Generate Report</h2>


### PR DESCRIPTION
## Summary
- allow creating custom categories and listing them from the backend
- add form on the frontend to add expenses selecting a category
- provide a button to create new categories via the UI
- document the new feature in the README

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685771515678832c9b2aec10bbd58d68