### PR TITLE
Switch backend to Go implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FinOps Controller
 
-This project is a minimal example of a financial control web application. It uses a FastAPI backend and a small frontend. Authentication integration should be implemented using Authentik or social OAuth providers (GitHub/Facebook) – currently a placeholder endpoint is provided.
+This project is a minimal example of a financial control web application. It uses a small Go backend and an Angular frontend. Authentication integration should be implemented using Authentik or social OAuth providers (GitHub/Facebook) – currently a placeholder endpoint is provided.
 
-The backend now runs on PostgreSQL and can be started together with the database (and an optional Angular frontend) using Docker Compose.
+The backend stores data in memory and can be started together with a PostgreSQL instance (unused for now) and the Angular frontend using Docker Compose.
 
 ## Running with Docker
 
@@ -17,9 +17,8 @@ The API will be available at `http://localhost:8000` and the Angular frontend at
 For development without Docker you can still run the backend manually:
 
 ```bash
-cd backend
-pip install -r requirements.txt
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/finops uvicorn app:app --reload
+cd backend-go
+go run main.go
 ```
 
 The old static HTML frontend is kept for reference in `frontend-static`.

--- a/backend-go/Dockerfile
+++ b/backend-go/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.23
+WORKDIR /app
+COPY . .
+RUN go build -o server
+CMD ["/app/server"]

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -1,0 +1,3 @@
+module finops
+
+go 1.23.8

--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type Category struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type Transaction struct {
+	ID          int       `json:"id"`
+	Description string    `json:"description"`
+	Amount      float64   `json:"amount"`
+	Date        time.Time `json:"date"`
+	CategoryID  int       `json:"category_id"`
+}
+
+var categories = []Category{}
+var transactions = []Transaction{}
+var categorySeq, transSeq int
+
+func main() {
+	http.HandleFunc("/categories", categoriesHandler)
+	http.HandleFunc("/categories/summary", summaryHandler)
+	http.HandleFunc("/transactions", transactionsHandler)
+	http.HandleFunc("/reports", reportsHandler)
+	http.HandleFunc("/auth/login", loginHandler)
+
+	http.ListenAndServe(":8000", nil)
+}
+
+func categoriesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		json.NewEncoder(w).Encode(categories)
+	case http.MethodPost:
+		var c Category
+		if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		categorySeq++
+		c.ID = categorySeq
+		categories = append(categories, c)
+		json.NewEncoder(w).Encode(c)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func summaryHandler(w http.ResponseWriter, r *http.Request) {
+	type Summary struct {
+		Category string  `json:"category"`
+		Total    float64 `json:"total"`
+	}
+	summaryMap := map[int]float64{}
+	for _, t := range transactions {
+		summaryMap[t.CategoryID] += t.Amount
+	}
+	var result []Summary
+	for _, c := range categories {
+		total := summaryMap[c.ID]
+		result = append(result, Summary{Category: c.Name, Total: total})
+	}
+	json.NewEncoder(w).Encode(result)
+}
+
+func transactionsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var t Transaction
+		if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		transSeq++
+		t.ID = transSeq
+		transactions = append(transactions, t)
+		json.NewEncoder(w).Encode(t)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func reportsHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	catParam := q.Get("category_id")
+	startParam := q.Get("start")
+	endParam := q.Get("end")
+
+	var catID int
+	var err error
+	if catParam != "" {
+		catID, err = strconv.Atoi(catParam)
+		if err != nil {
+			http.Error(w, "invalid category_id", http.StatusBadRequest)
+			return
+		}
+	}
+	var start, end time.Time
+	if startParam != "" {
+		start, err = time.Parse("2006-01-02", startParam)
+		if err != nil {
+			http.Error(w, "invalid start", http.StatusBadRequest)
+			return
+		}
+	}
+	if endParam != "" {
+		end, err = time.Parse("2006-01-02", endParam)
+		if err != nil {
+			http.Error(w, "invalid end", http.StatusBadRequest)
+			return
+		}
+	}
+	var result []Transaction
+	for _, t := range transactions {
+		if catID != 0 && t.CategoryID != catID {
+			continue
+		}
+		if !start.IsZero() && t.Date.Before(start) {
+			continue
+		}
+		if !end.IsZero() && t.Date.After(end) {
+			continue
+		}
+		result = append(result, t)
+	}
+	json.NewEncoder(w).Encode(result)
+}
+
+func loginHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Auth integration not implemented", http.StatusNotImplemented)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,7 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
   backend:
-    build: ./backend
-    environment:
-      DATABASE_URL: postgresql://postgres:postgres@db:5432/finops
+    build: ./backend-go
     depends_on:
       - db
     ports:


### PR DESCRIPTION
## Summary
- add a simple Go backend that mimics the FastAPI routes
- update docker-compose to build the Go backend
- refresh README with Go instructions

## Testing
- `go vet ./backend-go/...`
- `docker-compose config` *(fails: `docker-compose` not available)*

------
https://chatgpt.com/codex/tasks/task_e_685888830e34832c9f1733787baed86c